### PR TITLE
Use new queryResults from window state

### DIFF
--- a/altair-build.js
+++ b/altair-build.js
@@ -22,7 +22,7 @@ class ActionButtonJsonToCSV {
           return;
         } else {
           const email = emailVariableExists ? variables["json-csv-email"] : '';
-          const json = state.queryResult;
+          const json = state.queryResults?.length ? state.queryResults[0] : state.queryResult;
           const jsonString = encodeURIComponent(JSON.stringify(json));
           const url = `https://data.page/api/getcsv`;
   

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ class ActionButtonJsonToCSV {
           return;
         } else {
           const email = emailVariableExists ? variables["json-csv-email"] : '';
-          const json = state.queryResult;
+          const json = state.queryResults?.length ? state.queryResults[0] : state.queryResult;
           const jsonString = encodeURIComponent(JSON.stringify(json));
           const url = `https://data.page/api/getcsv`;
   

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "altair-graphql-plugin-json-to-csv",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "display_name": "Altair JSON-to-CSV",
   "description": "Converts json output to csv in Altair",
   "author_email": "isaacv@hey.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altair-graphql-plugin-json-to-csv",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Button to convert json to csv in Altair",
   "scripts": {
     "build": "node _build.js",


### PR DESCRIPTION
In recent versions of Altair (since v7.2.0), the `queryResult` has been removed and instead there is a `queryResults` list. This change checks for both options

https://altairgraphql.dev/api/core/plugin/context/context.interface/interfaces/PluginWindowState#queryresults